### PR TITLE
"Faked" useragent is not used during the pdf download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pdfs
 .vscode
 .DS_Store
+venv

--- a/flatex-fetch.py
+++ b/flatex-fetch.py
@@ -148,6 +148,9 @@ class Fetcher(object):
 
     def download_file(self, url):
         cookies = None
+        self.session.headers = {
+            'User-Agent': USER_AGENT
+        }
         if self.session_id is not None:
             cookies = {"JSESSIONID": self.session_id}
         return self.session.get(urljoin(URL_BASE, url), cookies=cookies)


### PR DESCRIPTION
At least for the german portal (flatex.de) this fix solved the issue with the "blocked" response